### PR TITLE
Add start and end step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ __pycache__
 node.zip
 .vs/
 ComfyUI-EulerDiscreteScheduler/.vs
+.idea
+.iml
+.vs
+EulerDiscrete.iml

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ More examples:
 <img width="1536" height="1088" alt="image" src="https://github.com/user-attachments/assets/1931af7e-1b3e-47c9-ac20-27add5135a71" />
 
 ## Changelog
-
+**1.0.4**
+add start and end step by etupa, with some fixes
 **1.0.3**
 
 - node publish action

--- a/__init__.py
+++ b/__init__.py
@@ -23,9 +23,7 @@ except ImportError:
 from comfy.samplers import SchedulerHandler, SCHEDULER_HANDLERS, SCHEDULER_NAMES
 
 # Default config for registering in ComfyUI
-default_config = {
-    "start_at_step": 0,
-    "end_at_step": 9999,
+default_config = {    
     "base_image_seq_len": 256,
     "base_shift": math.log(3),
     "invert_sigmas": False,
@@ -72,7 +70,7 @@ class FlowMatchEulerSchedulerNode:
                     "tooltip": "The starting step (index) of the sigma schedule to use. Set to 0 to start at the beginning (first step)."
                 }),
                 "end_at_step": ("INT", { # <-- NEW INPUT
-                    "default": 99999,
+                    "default": 9999,
                     "min": 0,
                     "max": 10000,
                     "tooltip": "The ending step (index) of the sigma schedule to use. Set higher than 'steps' to use all steps."
@@ -188,7 +186,7 @@ class FlowMatchEulerSchedulerNode:
         scheduler = FlowMatchEulerDiscreteScheduler.from_config(config)
         
         # 1. Generate the full sigma schedule
-        scheduler.set_timesteps(steps, device="cpu", mu=0.0)
+        
         # Determine device to use for sigma computation
         if device == "auto":
             # Auto-detect: use CUDA if available, otherwise CPU
@@ -218,19 +216,10 @@ class FlowMatchEulerSchedulerNode:
             
         return (sigmas_sliced,)
 
-
-# Import Flash Attention node
-# from .flash_attention_node import NODE_CLASS_MAPPINGS as FLASH_ATTN_MAPPINGS
-# from .flash_attention_node import NODE_DISPLAY_NAME_MAPPINGS as FLASH_ATTN_DISPLAY_MAPPINGS
-
 NODE_CLASS_MAPPINGS = {
     "FlowMatchEulerDiscreteScheduler (Custom)": FlowMatchEulerSchedulerNode,
-    # **FLASH_ATTN_MAPPINGS
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
     "FlowMatchEulerDiscreteScheduler (Custom)": "FlowMatch Euler Discrete Scheduler (Custom)",
-    **FLASH_ATTN_DISPLAY_MAPPINGS
-}
-    # **FLASH_ATTN_DISPLAY_MAPPINGS
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "erosdiffusion-eulerflowmatchingdiscretescheduler"
 description = "Noise Free images with Euler Discrete Scheduler in ComfyUI with Z-Image or other models"
-version = "1.0.3"
+version = "1.0.4"
 license = {file = "LICENSE.TXT"} 
 # classifiers = [
 #     # For OS-independent nodes (works on all operating systems)


### PR DESCRIPTION
This introduces two new parameters, start_at_step and end_at_step, to the FlowMatchEulerDiscreteScheduler node.

This enhancement allows users to truncate the generated sigma schedule, providing advanced control over the sampling process.